### PR TITLE
Add iamMember: prefix to bigquery dataset; upgrade Google provider

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -79,7 +79,7 @@ resource "google_bigquery_dataset_iam_member" "self" {
   if var.project_id != "" && startswith(member.role, "bigquery-dataset:") }
 
   dataset_id = split(":", each.value.role)[2]
-  member     = each.value.member
+  member     = startswith(each.value.member, "principal://") ? "iamMember:${each.value.member}" : each.value.member
   project    = local.target_id
   role = startswith(split(":", each.value.role)[1], "project:") ? "projects/${var.project_id}/roles/${substr(split(":", each.value.role)[1], 8, -1)}" : (
     startswith(split(":", each.value.role)[1], "org:") ?

--- a/main.tf
+++ b/main.tf
@@ -79,7 +79,7 @@ resource "google_bigquery_dataset_iam_member" "self" {
   if var.project_id != "" && startswith(member.role, "bigquery-dataset:") }
 
   dataset_id = split(":", each.value.role)[2]
-  member     = startswith(each.value.member, "principal://") ? "iamMember:${each.value.member}" : each.value.member
+  member     = startswith(each.value.member, "principal") ? "iamMember:${each.value.member}" : each.value.member
   project    = local.target_id
   role = startswith(split(":", each.value.role)[1], "project:") ? "projects/${var.project_id}/roles/${substr(split(":", each.value.role)[1], 8, -1)}" : (
     startswith(split(":", each.value.role)[1], "org:") ?

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.3"
+      version = ">= 7.12.0"
     }
     null = {
       source  = "hashicorp/null"


### PR DESCRIPTION
[Per the documentation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_dataset_iam#member/members-2), this should fix the error in the apply we're seeing on https://github.com/VivaaHealth/vivaa/pull/73224:

```
╷
│ Error: Error applying IAM policy for Bigquery Dataset notable-core-prod/m3ter: Failed to parse BigQuery Dataset IAM member type: principal://iam.googleapis.com/projects/687465512546/locations/global/workloadIdentityPools/notable-devops-prod.svc.id.goog/subject/ns/buildkite/sa/prod-bigquery-agent
│ 
│   with module.permissions.google_bigquery_dataset_iam_member.self["principal://iam.googleapis.com/projects/687465512546/locations/global/workloadIdentityPools/notable-devops-prod.svc.id.goog/subject/ns/buildkite/sa/prod-bigquery-agent-bigquery-dataset:bigquery.metadataViewer:m3ter"],
│   on .terraform/modules/permissions/main.tf line 77, in resource "google_bigquery_dataset_iam_member" "self":
│   77: resource "google_bigquery_dataset_iam_member" "self" {
│ 
╵

module.permissions.google_bigquery_dataset_iam_member.self["principal://iam.googleapis.com/projects/687465512546/locations/global/workloadIdentityPools/notable-devops-prod.svc.id.goog/subject/ns/buildkite/sa/prod-bigquery-agent-bigquery-dataset:bigquery.metadataViewer:m3ter"]: Creating...
Failure during /github/home/.tenv/Terraform/1.9.8/terraform call : exited with code 1

```