### PR TITLE
define resources explicitly

### DIFF
--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -4,7 +4,7 @@
 # terraform-docs markdown . --recursive --output-file test.md
 
 formatter: markdown
-version: "0.17"
+version: "0.20"
 footer-from: ""
 header-from: main.tf
 #output:

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -6,7 +6,7 @@
 
 plugin "google" {
     enabled = true
-    version = "0.22.1"
+    version = "0.37.1"
     source  = "github.com/terraform-linters/tflint-ruleset-google"
 }
 

--- a/README.md
+++ b/README.md
@@ -8,29 +8,51 @@
 
 Terraform module for Google IAM memberships
 
-## Supports
-
+Role parameters:
 - Google roles
 - Project custom roles
 - Organization custom roles
+- IAM Conditions
+
+Resource bindings to:
+- Organization
+- Project
 - Storage bucket roles
 - BigQuery dataset roles
 - BigQuery table roles
-- IAM Conditions
 - Cloud Run jobs
+- Secrets
 
 ## Role formats
 
-- bigquery-dataset:[org|project|]-role:datasetId
-- bigquery-table:[org|project|]-role:datasetId:tableId
-- billing:role
-- [org|project|]-role
-- storage:[org|project|]-role:bucket
-- cloud-run-job:[org|project|]-role:jobName
+The role strings taken as input embed multiple identifiers for where the IAM binding is made, what role is bound, and to what resource. Custom project/org level roles require a prefix as well.
+
+The general format is:
+`<resource type>:[<org|project>-]<role name>:<resource type parameters: ...>`
+
+### Resource type
+A prefix/alias that controls what type of resource the binding is made on. Can be excluded, which will make the binding on the configured project/organization by default.
+
+### Role name
+The ID of the role to bind. For default roles, *do not* include the `roles/` prefix. For custom roles, it depends on where the role is configured. If in the project, prefix the ID with `project-`. If in the organization, prefix the ID with `org-`.
+
+### Resource type parameters
+An identifier for the resource the binding is made too. Usually a name/single ID, sometimes multiple colon-separated values. Depends on resource type, see below.
+
+### Supported resource formats
+
+| resource type | resource type | resource type params |
+|---|---|---|
+| project/org | null | null |
+| storage bucket  |  storage | bucket name |
+| bigquery dataset | bigquery-dataset | datasetId |
+| bigquery table | bigquery-table | datasetId:tableId |
+| cloud run jobs | cloud-run-job | job name |
+| billing acct | billing | null |
 
 ## Required Inputs
 
-organization\_id or project\_id MUST be specified
+organization\\_id XOR project\\_id MUST be specified
 
 ## Usage
 
@@ -51,15 +73,15 @@ module "example" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 5.3 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 7.12.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 5.4.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.2.1 |
+| <a name="provider_google"></a> [google](#provider\_google) | 7.12.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.4 |
 
 ## Modules
 
@@ -72,6 +94,7 @@ No modules.
 | [google_bigquery_dataset_iam_member.self](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_dataset_iam_member) | resource |
 | [google_bigquery_table_iam_member.self](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_table_iam_member) | resource |
 | [google_billing_account_iam_member.self](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/billing_account_iam_member) | resource |
+| [google_cloud_run_v2_job_iam_member.self](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_job_iam_member) | resource |
 | [google_organization_iam_member.self](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_member) | resource |
 | [google_project_iam_member.self](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_storage_bucket_iam_member.self](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
@@ -83,7 +106,8 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_billing_account_name"></a> [billing\_account\_name](#input\_billing\_account\_name) | Billing account name. | `string` | `""` | no |
-| <a name="input_members"></a> [members](#input\_members) | List of members and roles to add them to. | <pre>list(object({<br>    member = string<br>    #condition = optional(object({<br>    #  description = string<br>    #  expression  = string<br>    #  title       = string<br>    #}))<br>    roles = list(object({<br>      role = string<br>      condition = optional(object({<br>        description = string<br>        expression  = string<br>        title       = string<br>      }))<br>    }))<br>  }))</pre> | n/a | yes |
+| <a name="input_default_location"></a> [default\_location](#input\_default\_location) | The default location | `string` | `null` | no |
+| <a name="input_members"></a> [members](#input\_members) | List of members and roles to add them to. | <pre>list(object({<br/>    member = string<br/>    roles = list(object({<br/>      role     = string<br/>      resource = optional(string, "base")<br/>      location = optional(string)<br/>      condition = optional(object({<br/>        description = string<br/>        expression  = string<br/>        title       = string<br/>      }))<br/>    }))<br/>  }))</pre> | n/a | yes |
 | <a name="input_organization_id"></a> [organization\_id](#input\_organization\_id) | Organization ID. | `string` | `""` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project ID. | `string` | `""` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -7,27 +7,51 @@
  *
  * Terraform module for Google IAM memberships
  *
- * ## Supports
- *
+ * Role parameters:
  * - Google roles
  * - Project custom roles
  * - Organization custom roles
+ * - IAM Conditions
+ *
+ * Resource bindings to:
+ * - Organization
+ * - Project
  * - Storage bucket roles
  * - BigQuery dataset roles
  * - BigQuery table roles
- * - IAM Conditions
+ * - Cloud Run jobs
+ * - Secrets
  *
  * ## Role formats
  *
- * - bigquery-dataset:[org|project|]-role:datasetId
- * - bigquery-table:[org|project|]-role:datasetId:tableId
- * - billing:role
- * - [org|project|]-role
- * - storage:[org|project|]-role:bucket
+ * The role strings taken as input embed multiple identifiers for where the IAM binding is made, what role is bound, and to what resource. Custom project/org level roles require a prefix as well.
+ *
+ * The general format is:
+ * `<resource type>:[<org|project>-]<role name>:<resource type parameters: ...>`
+ *
+ * ### Resource type
+ * A prefix/alias that controls what type of resource the binding is made on. Can be excluded, which will make the binding on the configured project/organization by default.
+ *
+ * ### Role name
+ * The ID of the role to bind. For default roles, *do not* include the `roles/` prefix. For custom roles, it depends on where the role is configured. If in the project, prefix the ID with `project-`. If in the organization, prefix the ID with `org-`.
+ *
+ * ### Resource type parameters
+ * An identifier for the resource the binding is made too. Usually a name/single ID, sometimes multiple colon-separated values. Depends on resource type, see below.
+ *
+ * ### Supported resource formats
+ *
+ * | resource type | resource type | resource type params |
+ * |---|---|---|
+ * | project/org | null | null |
+ * | storage bucket  |  storage | bucket name |
+ * | bigquery dataset | bigquery-dataset | datasetId |
+ * | bigquery table | bigquery-table | datasetId:tableId |
+ * | cloud run jobs | cloud-run-job | job name |
+ * | billing acct | billing | null |
  *
  * ## Required Inputs
  *
- * organization_id or project_id MUST be specified
+ * organization\_id XOR project\_id MUST be specified
  *
  */
 
@@ -40,6 +64,9 @@
 #   google_secret_manager_secret_iam_member - for single secret
 #   google_service_account_iam_member - allow principal to impersonate service account
 #   more as needed
+# TODO
+# Role format: sa:[org|project|]-<role>:<serviceAccount>
+#resource "google_service_account_iam_member" "self" {}
 
 # TODO: ?? update to be 1 of project, org, or billing required
 resource "null_resource" "org_proj_precondition_validation" {
@@ -58,33 +85,35 @@ locals {
       [
         for role in member.roles :
         {
-          member = member.member,
-          role   = role.role,
-          # note lookup function doesn't work because in an object all keys
-          # are always present
+          member   = member.member,
+          resource = role.resource,
+          role = (
+            split(":", role.role)[0] == "project" ?
+            "projects/${var.project_id}/roles/${split(":", role.role)[1]}"
+            :
+            split(":", role.role)[0] == "org" ?
+            "organizations/${var.organization_id}/roles/${split(":", role.role)[1]}"
+            :
+            "roles/${role.role}"
+          )
+          # note lookup function doesn't work because in an object all keys are always present
           location  = role.location == null ? var.default_location : role.location,
           condition = role.condition
         }
       ]
   ])
-  # If no role.condition
-
-  # Resources outside this list get the generic google_project_iam
-  supported_resources = ["bigquery-dataset", "bigquery-table", "storage", "cloud-run-job"]
 }
+
 
 # Role format: bigquery-dataset:[org|project|]-<role>:datasetId
 resource "google_bigquery_dataset_iam_member" "self" {
-  for_each = { for member in local.members : "${member.member}-${member.role}" => member
-  if var.project_id != "" && startswith(member.role, "bigquery-dataset:") }
+  for_each = { for member in local.members : "${member.member}-${member.role}-${member.resource}" => member
+  if var.project_id != "" && startswith(member.resource, "bigquery-dataset:") }
 
-  dataset_id = split(":", each.value.role)[2]
+  dataset_id = split(":", each.value.resource)[1]
   member     = startswith(each.value.member, "principal") ? "iamMember:${each.value.member}" : each.value.member
   project    = local.target_id
-  role = startswith(split(":", each.value.role)[1], "project:") ? "projects/${var.project_id}/roles/${substr(split(":", each.value.role)[1], 8, -1)}" : (
-    startswith(split(":", each.value.role)[1], "org:") ?
-    "organizations/${var.organization_id}/roles/${substr(split(":", each.value.role)[1], 4, -1)}"
-  : "roles/${split(":", each.value.role)[1]}")
+  role       = each.value.role
   dynamic "condition" {
     for_each = lookup(each.value, "condition", null) != null ? [each.value.condition] : []
     content {
@@ -97,17 +126,14 @@ resource "google_bigquery_dataset_iam_member" "self" {
 
 # Role format: bigquery-table:[org|project|]-<role>:datasetId:tableId
 resource "google_bigquery_table_iam_member" "self" {
-  for_each = { for member in local.members : "${member.member}-${member.role}" => member
-  if var.project_id != "" && startswith(member.role, "bigquery-table:") }
+  for_each = { for member in local.members : "${member.member}-${member.role}-${member.resource}" => member
+  if var.project_id != "" && startswith(member.resource, "bigquery-table:") }
 
-  dataset_id = split(":", each.value.role)[2]
+  dataset_id = split(":", each.value.resource)[1]
   member     = each.value.member
   project    = local.target_id
-  role = startswith(split(":", each.value.role)[1], "project:") ? "projects/${var.project_id}/roles/${substr(split(":", each.value.role)[1], 8, -1)}" : (
-    startswith(split(":", each.value.role)[1], "org:") ?
-    "organizations/${var.organization_id}/roles/${substr(split(":", each.value.role)[1], 4, -1)}"
-  : "roles/${split(":", each.value.role)[1]}")
-  table_id = split(":", each.value.role)[3]
+  role       = each.value.role
+  table_id   = split(":", each.value.resource)[2]
   dynamic "condition" {
     for_each = lookup(each.value, "condition", null) != null ? [each.value.condition] : []
     content {
@@ -118,26 +144,21 @@ resource "google_bigquery_table_iam_member" "self" {
   }
 }
 
-# Role format: billing:<role>
 resource "google_billing_account_iam_member" "self" {
-  for_each = { for member in local.members : "${member.member}-${member.role}" => member
-  if var.billing_account_name != "" && startswith(member.role, "billing:") }
+  for_each = { for member in local.members : "${member.member}-${member.role}-${member.resource}" => member
+  if var.billing_account_name != "" && startswith(member.resource, "billing:") }
 
   billing_account_id = data.google_billing_account.self[0].id
   member             = each.value.member
   role               = "roles/${split(":", each.value.role)[1]}"
 }
 
-# Role format: [org|]-<role>
 resource "google_organization_iam_member" "self" {
-  for_each = { for member in local.members : "${member.member}-${member.role}" => member
-  if var.organization_id != "" && !contains(local.supported_resources, element(split(":", member.role), 0)) }
+  for_each = { for member in local.members : "${member.member}-${member.role}-${member.resource}" => member
+  if var.organization_id != "" && member.resource == "base" }
 
   org_id = local.target_id
-  role = (
-    startswith(each.value.role, "org:") ?
-    "organizations/${var.organization_id}/roles/${substr(each.value.role, 4, -1)}"
-  : "roles/${each.value.role}")
+  role   = each.value.role
   member = each.value.member
   dynamic "condition" {
     for_each = lookup(each.value, "condition", null) != null ? [each.value.condition] : []
@@ -149,21 +170,15 @@ resource "google_organization_iam_member" "self" {
   }
 }
 
-# Role format: [org|project|]-<role>
+
 resource "google_project_iam_member" "self" {
-  for_each = { for member in local.members : "${member.member}-${member.role}" => member
-  if var.project_id != "" && !contains(local.supported_resources, element(split(":", member.role), 0)) }
+  for_each = { for member in local.members : "${member.member}-${member.role}-${member.resource}" => member
+  if var.project_id != "" && member.resource == "base" }
 
   project = local.target_id
-  role = startswith(each.value.role, "project:") ? "projects/${var.project_id}/roles/${substr(each.value.role, 8, -1)}" : (
-    startswith(each.value.role, "org:") ?
-    "organizations/${var.organization_id}/roles/${substr(each.value.role, 4, -1)}"
-  : "roles/${each.value.role}")
-  member = each.value.member
+  role    = each.value.role
+  member  = each.value.member
   dynamic "condition" {
-    # NO - for_each = each.value.condition[*]
-    # NO - for_each = each.value.condition != null ? [each.value.condition] : []
-    # NO - for_each = { for condition in each.value.condition[*] : "${condition.title}-${condition.description}-${condition.expression}" => condition }
     for_each = lookup(each.value, "condition", null) != null ? [each.value.condition] : []
     content {
       description = condition.value.description
@@ -172,23 +187,15 @@ resource "google_project_iam_member" "self" {
     }
   }
 }
-
-# TODO
-# Role format: sa:[org|project|]-<role>:<serviceAccount>
-#resource "google_service_account_iam_member" "self" {}
 
 # Role format: storage:[org|project|]-<role>:<bucket>
 resource "google_storage_bucket_iam_member" "self" {
-  for_each = { for member in local.members : "${member.member}-${member.role}" => member
-  if var.project_id != "" && startswith(member.role, "storage:") }
+  for_each = { for member in local.members : "${member.member}-${member.role}-${member.resource}" => member
+  if var.project_id != "" && startswith(member.resource, "storage:") }
 
-  bucket = one(flatten(regexall("[^:]+:[^:]+:(.*)", each.value.role)))
+  bucket = split(":", each.value.resource)[1]
   member = each.value.member
-  # Role format: storage:(project|org|)-<role>:<bucket>
-  role = startswith(each.value.role, "storage:project-") ? "projects/${var.project_id}/roles/${one(flatten(regexall("[^:]+:([^:]+):", each.value.role)))}" : (
-    startswith(each.value.role, "storage:org-") ?
-    "organizations/${var.organization_id}/roles/${one(flatten(regexall("[^:]+:([^:]+):", each.value.role)))}"
-  : "roles/${one(flatten(regexall("[^:]+:([^:]+):", each.value.role)))}")
+  role   = each.value.role
   dynamic "condition" {
     for_each = lookup(each.value, "condition", null) != null ? [each.value.condition] : []
     content {
@@ -203,18 +210,15 @@ resource "google_storage_bucket_iam_member" "self" {
 # Role format: cloud-run-job:[org|project|]-<role>:job-name
 resource "google_cloud_run_v2_job_iam_member" "self" {
   for_each = {
-    for member in local.members : "${member.member}-${member.role}" => member
-    if var.project_id != "" && startswith(member.role, "cloud-run-job:")
+    for member in local.members : "${member.member}-${member.role}-${member.resource}" => member
+    if var.project_id != "" && startswith(member.resource, "cloud-run-job:")
   }
 
-  name     = split(":", each.value.role)[2]
+  name     = split(":", each.value.resource)[1]
   member   = each.value.member
   project  = local.target_id
   location = each.value.location
-  role = startswith(split(":", each.value.role)[1], "project:") ? "projects/${var.project_id}/roles/${substr(split(":", each.value.role)[1], 8, -1)}" : (
-    startswith(split(":", each.value.role)[1], "org:") ?
-    "organizations/${var.organization_id}/roles/${substr(split(":", each.value.role)[1], 4, -1)}"
-  : "roles/${split(":", each.value.role)[1]}")
+  role     = each.value.role
   dynamic "condition" {
     for_each = lookup(each.value, "condition", null) != null ? [each.value.condition] : []
     content {

--- a/variables.tf
+++ b/variables.tf
@@ -22,18 +22,13 @@ variable "default_location" {
 }
 
 # Allow global condition for all member roles
-#  TODO: add code to handle new data
 variable "members" {
   description = "List of members and roles to add them to."
   type = list(object({
     member = string
-    #condition = optional(object({
-    #  description = string
-    #  expression  = string
-    #  title       = string
-    #}))
     roles = list(object({
       role     = string
+      resource = optional(string, "base")
       location = optional(string)
       condition = optional(object({
         description = string


### PR DESCRIPTION
This refactor breaks up the existing colon separated "role" strings in two, one for the resource and one for the role. 

I wanted to de-duplicate the repeated logic for each resource's `role` param and put it all where local.members is defined. It ended up pretty monstrous in order to handle the distinctions between resource types and default/custom-project/custom-org roles. I didn't look forward to to maintaining it, and we'd have to each time we add another resource type. 

Changing the input felt worth it to simplify that future maintenance, and standardizes how the role vs resource strings are interpreted downstream.

This is a breaking change for input variables.